### PR TITLE
Fix for dd argument

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ cd ..
 if [ ! -d "$bin" ]; then
   mkdir bin
 fi
-dd if=/dev/zero of=bin/bmfs.image bs=1M count=128
+dd if=/dev/zero of=bin/bmfs.image bs=1m count=128
 
 ./build.sh
 ./format.sh


### PR DESCRIPTION
Hi,
Your script gives this error, because the argument to dd was 1M, and not 1m.

<pre>
Resolving deltas: 100% (667/667), done.
dd: bs: illegal numeric value
gcc -o bmfs bmfs.c
</pre>
