### PR TITLE
Missing one step to change to ../bin for Compiling Newlib instructions.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ The test application can also be built manually:
 	gcc -I newlib-2.2.0/newlib/libc/include/ -c test.c -o test.o
 	ld -T app.ld -o test.app crt0.o test.o libc.a
 	cp test.app ../bin
+    cd ../bin
 	./bmfs bmfs.image create test.app 2
 	./bmfs bmfs.image write test.app
 	cd ..


### PR DESCRIPTION
In your newlib build instructions just missing the cd ../bin 

cd newlib
gcc -I newlib-2.2.0/newlib/libc/include/ -c test.c -o test.o
ld -T app.ld -o test.app crt0.o test.o libc.a
cp test.app ../bin
**cd ../bin**
./bmfs bmfs.image create test.app 2
./bmfs bmfs.image write test.app
cd ..
./run.sh
