### PR TITLE
gen lst files for pgdb

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd src/BareMetal-OS/programs/
-nasm $1.asm -o ../../../bin/$1.app
+nasm $1.asm -o ../../../bin/$1.app -l ../../../lst/$1.lst
 if [ $? -eq 0 ]; then
 cd ../../../bin
 ./bmfs bmfs.image create $1.app 2

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,8 @@
 cd src/Pure64
 ./build.sh
 mv *.sys ../../bin/
+mv *.lst ../../lst/
 cd ..
 
 cd BareMetal-OS/os
-nasm kernel64.asm -o ../../../bin/kernel64.sys
+nasm kernel64.asm -o ../../../bin/kernel64.sys -l ../../../lst/kernel64.lst

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd bin
-qemu-system-x86_64 -vga std -smp 8 -m 256 -drive id=disk,file=bmfs.image,if=none,format=raw -device ahci,id=ahci -device ide-drive,drive=disk,bus=ahci.0 -name "BareMetal OS" -net nic,model=i82551
+qemu-system-x86_64 -vga std -smp 8 -m 256 -drive id=disk,file=bmfs.image,if=none,format=raw -device ahci,id=ahci -device ide-drive,drive=disk,bus=ahci.0 -name "BareMetal OS" -net nic,model=i82551 $*

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,7 @@ cd ..
 
 if [ ! -d "$bin" ]; then
   mkdir bin
+  mkdir lst
 fi
 platform=`uname`
 case "${platform}" in


### PR DESCRIPTION
- set.sh creates the lst dir
- app.sh generates lst files
- run.sh adjusted to allow the extra qemu args (-s -S)
- build.sh collects lst files in the lst dir (parallel to the bin dir) so pgdb can be invoked with a shell wildcard:
  
  $ ./run.sh -s -S
  $ ./pgdb.py -nasmlst ~/git/BareMetal/lst/*

These changes are likely incomplete, I've only progressed far enough to step through the boot loader and possibly into the kernel...
