### PR TITLE
Added booting from floppy

### DIFF
--- a/baremetal.sh
+++ b/baremetal.sh
@@ -18,7 +18,7 @@ function baremetal_setup {
 
 	echo -n "Pulling code from GitHub... "
 	cd src
-	git clone https://github.com/ReturnInfinity/Pure64.git -q
+	git clone https://github.com/isoux/Pure64 -q
 	git clone https://github.com/ReturnInfinity/BareMetal.git -q
 	git clone https://github.com/ReturnInfinity/BareMetal-Monitor.git -q
 	git clone https://github.com/ReturnInfinity/BMFS.git -q
@@ -62,6 +62,8 @@ function baremetal_setup {
 	else
 		dd if=/dev/zero of=fat32.img count=128 bs=1048576 > /dev/null 2>&1
 	fi
+	# Create Floppy image
+	dd if=/dev/zero of=floppy.img count=2880 bs=512 > /dev/null 2>&1
 	cd ..
 	echo "OK"
 
@@ -128,6 +130,8 @@ function baremetal_build {
 	mv "src/Pure64/bin/uefi-debug.txt" "${OUTPUT_DIR}/uefi-debug.txt"
 	mv "src/Pure64/bin/bios.sys" "${OUTPUT_DIR}/bios.sys"
 	mv "src/Pure64/bin/bios-debug.txt" "${OUTPUT_DIR}/bios-debug.txt"
+	mv "src/Pure64/bin/bios-floppy.sys" "${OUTPUT_DIR}/bios-floppy.sys"
+	mv "src/Pure64/bin/bios-floppy-debug.txt" "${OUTPUT_DIR}/bios-floppy-debug.txt"
 	mv "src/BareMetal/bin/kernel.sys" "${OUTPUT_DIR}/kernel.sys"
 	mv "src/BareMetal/bin/kernel-debug.txt" "${OUTPUT_DIR}/kernel-debug.txt"
 	mv "src/BareMetal-Monitor/bin/monitor.bin" "${OUTPUT_DIR}/monitor.bin"
@@ -174,7 +178,11 @@ function baremetal_install {
 
 	# Create FAT32/BMFS hybrid disk
 	cat fat32.img bmfs.img > baremetal_os.img
-
+	
+	# Create FLOPPY bootable system image - disk
+	cat bios-floppy.sys pure64.sys kernel.sys monitor.bin > floppy.sys
+	dd if=floppy.sys of=floppy.img conv=notrunc > /dev/null 2>&1
+	
 	cd ..
 }
 


### PR DESCRIPTION
According to the [discussion:](https://github.com/ReturnInfinity/BareMetal-OS/discussions/106)
Added the ability to boot from a floppy. The results so far are the same as booting from a USB stick. 
A request has also been launched on the Pure64 repository.
If the request is accepted, line 21 in the baremetal.sh file should be reverted so it doesn't pull the code from my repository.

