### PR TITLE
Update baremetal.sh

### DIFF
--- a/baremetal.sh
+++ b/baremetal.sh
@@ -62,7 +62,6 @@ function baremetal_setup {
 	else
 		dd if=/dev/zero of=fat32.img count=128 bs=1048576 > /dev/null 2>&1
 	fi
-	dd if=/dev/zero of=floppy.img count=2880 bs=512 > /dev/null 2>&1
 	cd ..
 	echo "OK"
 
@@ -151,6 +150,8 @@ function baremetal_build {
 	# Prep UEFI loader
 	cp uefi.sys BOOTX64.EFI
 	dd if=software.sys of=BOOTX64.EFI bs=4096 seek=1 conv=notrunc > /dev/null 2>&1
+
+ 	dd if=/dev/zero of=floppy.img count=2880 bs=512 > /dev/null 2>&1
 
 	cd ..
 }


### PR DESCRIPTION
`dd if=/dev/zero of=floppy.img count=2880 bs=512 > /dev/null 2>&1`
It should be in the baremetal_build function. Otherwise, a proper 1.5 Mb image is not formed if some change is made in the asm code ...

My fault, but after trying the code after merging today, I noticed this.