### PR TITLE
remove baremetal_run from baremetal_app

### DIFF
--- a/baremetal.sh
+++ b/baremetal.sh
@@ -418,7 +418,6 @@ function baremetal_app {
 		./bmfs bmfs.img write $1
 		cat fat32.img bmfs.img > baremetal_os.img
 		cd ..
-		baremetal_run
 	else
 		echo "$1 does not exist."
 		cd ..


### PR DESCRIPTION
sometimes i don't want to run qemu and just want to build the image.
 eg. want to run bochs after running baremetal.sh k.app