### PR TITLE
Change the shebang in baremetal.sh so that it works across all systems.

### DIFF
--- a/baremetal.sh
+++ b/baremetal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +e
 export EXEC_DIR="$PWD"


### PR DESCRIPTION
When I tried to use the script on my NixOS system, it failed and gave me a fairly cryptic error. This PR fixes that. The issue with the script is that, on some operating systems, the Bash executable is located in unusual places, and I think you should account for that.